### PR TITLE
GoTo/GoSub call seek performance improvement:

### DIFF
--- a/src/script/Script.cpp
+++ b/src/script/Script.cpp
@@ -254,13 +254,14 @@ std::ostream & operator<<(std::ostream & os, const ScriptParameters & parameters
 
 size_t FindScriptPos(const EERIE_SCRIPT * es, std::string_view str) {
 	
-	std::map<string,int>::iterator itCall; // TODO performance tests in some 100KB+ script where the target is at it's end
-	itCall = es->shortcutCalls.find(str);
-	if(itCall != es->shortcutCalls.end()) {
-		return itCall->second;
-	}
-	
 	// TODO(script-parser) remove, respect quoted strings
+	
+	if(str.size() >= 2 && str[0] == '>' && str[1] == '>') { // uses the cache only for GoTo/GoSub calls
+		auto it = es->shortcutCalls.find(std::string(str));
+		if(it != es->shortcutCalls.end()) {
+			return it->second;
+		}
+	}
 	
 	for(size_t pos = 0; pos < es->data.size(); pos++) {
 		
@@ -276,9 +277,7 @@ size_t FindScriptPos(const EERIE_SCRIPT * es, std::string_view str) {
 		// Check if the line is commented out!
 		for(size_t p = pos; es->data[p] != '/' || es->data[p + 1] != '/'; p--) {
 			if(es->data[p] == '\n' || p == 0) {
-				pos += str.length();
-				es->shortcutCalls.insert( std::pair<string,int>(str,pos) );
-				return pos;
+				return pos + str.length();
 			}
 		}
 		

--- a/src/script/Script.h
+++ b/src/script/Script.h
@@ -50,6 +50,7 @@ ZeniMax Media Inc., Suite 120, Rockville, Maryland 20850 USA.
 #include <stddef.h>
 #include <cstring>
 #include <limits>
+#include <map>
 #include <ostream>
 #include <string>
 #include <string_view>
@@ -188,7 +189,8 @@ struct EERIE_SCRIPT {
 	bool valid = false;
 	std::string data;
 	size_t shortcut[SM_MAXCMD];
-	std::map<string,int> shortcutCalls;
+	std::map<std::string, size_t> shortcutCalls; // key cannot be std::string_view here as it needs to hold the new string data
+	std::string file;
 
 	EERIE_SCRIPT() noexcept {
 		memset(&shortcut, 0, sizeof(shortcut));


### PR DESCRIPTION
Creates a sorted cache map (that considers overrides) and avoids seeking them on every call.